### PR TITLE
Fixed node version so we can use it with a 0.5.x :)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   }
 , "directories" : { "lib" : "./lib" }
 , "main" : "./lib/index"
-, "engines" : { "node" : "0.4.x" }
+, "engines" : { "node" : ">=0.4.x" }
 , "licenses" :
   [ { "type" : "MIT"
     , "url" : "http://github.com/samsonjs/format/raw/master/LICENSE"


### PR DESCRIPTION
npm install format --force 
npm ERR! Unsupported
npm ERR! Not compatible with your version of node/npm: format@0.1.1
npm ERR! Required: {"node":"0.4.x"}
npm ERR! Actual:   {"npm":"1.0.5","node":"v0.5.0-pre"}
npm ERR! 
npm ERR! System Linux 2.6.35-28-generic
npm ERR! command "node" "/usr/local/bin/npm" "--force" "install" "format"
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /xxx/yyy/dev/npm-debug.log
npm not ok
